### PR TITLE
Adding an address to the admin menu

### DIFF
--- a/longclaw/longclawshipping/wagtail_hooks.py
+++ b/longclaw/longclawshipping/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, modeladmin_register
 )
-from longclaw.longclawshipping.models import ShippingRate
+from longclaw.longclawshipping.models import ShippingRate, Address
 
 
 class ShippingRateModelAdmin(ModelAdmin):
@@ -15,3 +15,15 @@ class ShippingRateModelAdmin(ModelAdmin):
 
 
 modeladmin_register(ShippingRateModelAdmin)
+
+class AddressModelAdmin(ModelAdmin):
+    model = Address
+    menu_label = 'Address'
+    menu_order = 220
+    menu_icon = 'group'
+    add_to_settings_menu = False
+    exclude_from_explorer = True
+    list_display = ('name', 'line_1', 'city', 'country')
+
+
+modeladmin_register(AddressModelAdmin)


### PR DESCRIPTION
Allows you to view and edit addresses through the admin panel.

The address item supplements item SHIPPING.