### PR TITLE
Correct date return month_start, month_end

### DIFF
--- a/longclaw/longclawstats/stats.py
+++ b/longclaw/longclawstats/stats.py
@@ -11,8 +11,8 @@ from longclaw.longclaworders.models import Order, OrderItem
 def current_month():
     now = datetime.now()
     n_days = calendar.monthrange(now.year, now.month)[1]
-    month_start = datetime.strptime('1{}{}'.format(now.month, now.year), '%d%m%Y')
-    month_end = datetime.strptime('{}{}{}'.format(n_days, now.month, now.year), '%d%m%Y')
+    month_start = datetime.strptime('{}{}{}'.format(now.year, now.month, 1), '%Y%m%d')
+    month_end = datetime.strptime('{}{}{}'.format(now.year,now.month, n_days), '%Y%m%d')
     return month_start, month_end
 
 


### PR DESCRIPTION
Changes solve the problem of the incorrect date to "def current_month()". The error occured due to incorrect date format month_start.