### PR TITLE
Jinja2 Tag Support

### DIFF
--- a/longclaw/basket/jinja2/basket/add_to_basket.html
+++ b/longclaw/basket/jinja2/basket/add_to_basket.html
@@ -1,0 +1,16 @@
+<button id="btn-add-to-basket" class="{{btn_class}}" data-variant-id="{{variant_id}}">
+{{btn_text}}
+</button>
+{{ longclaw_vendors_bundle()|safe }}
+{{ longclaw_client_bundle()|safe }}
+<script type="text/javascript">
+  var btn = document.getElementById('btn-add-to-basket');
+  btn.addEventListener("click", function (e) {
+    longclawclient.basketList.post({
+      prefix: "{{ longclaw_api_url_prefix() }}",
+      data: {
+        variant_id: e.target.dataset.variantId
+      }
+    });
+  });
+</script>

--- a/longclaw/basket/jinja2tags.py
+++ b/longclaw/basket/jinja2tags.py
@@ -1,0 +1,34 @@
+import jinja2
+from jinja2 import nodes
+from jinja2.ext import Extension
+
+from django.template.loader import get_template
+
+from longclaw.basket.templatetags.basket_tags import get_basket_items
+from longclaw.basket.utils import get_basket_items
+
+
+def add_to_basket_btn(variant_id, btn_class="btn btn-default", btn_text="Add To Basket"):
+    """Button to add an item to the basket
+    """
+    basket_template = get_template('basket/add_to_basket.html')
+
+    return basket_template.render(context={
+        'btn_class': btn_class,
+        'variant_id': variant_id,
+        'btn_text': btn_text
+    })
+
+
+class LongClawBasketExtension(Extension):
+    def __init__(self, environment):
+        super(LongClawBasketExtension, self).__init__(environment)
+
+        self.environment.globals.update({
+            'basket': jinja2.contextfunction(get_basket_items),
+            'add_to_basket_btn': add_to_basket_btn,
+        })
+
+
+# Nicer import names
+basket = LongClawBasketExtension

--- a/longclaw/basket/jinja2tags.py
+++ b/longclaw/basket/jinja2tags.py
@@ -4,8 +4,8 @@ from jinja2.ext import Extension
 
 from django.template.loader import get_template
 
-from longclaw.basket.templatetags.basket_tags import get_basket_items
-from longclaw.basket.utils import get_basket_items
+from .templatetags.basket_tags import get_basket_items
+from .utils import get_basket_items
 
 
 def add_to_basket_btn(variant_id, btn_class="btn btn-default", btn_text="Add To Basket"):

--- a/longclaw/checkout/jinja2tags.py
+++ b/longclaw/checkout/jinja2tags.py
@@ -1,0 +1,21 @@
+import jinja2
+import jinja2.nodes
+from jinja2.ext import Extension
+
+from django.template.loader import get_template
+
+from longclaw.checkout.templatetags.longclawcheckout_tags import gateway_client_js, gateway_token
+
+
+class LongClawCheckoutExtension(Extension):
+    def __init__(self, environment):
+        super(LongClawCheckoutExtension, self).__init__(environment)
+
+        self.environment.globals.update({
+            'gateway_client_js': gateway_client_js,
+            'gateway_token': gateway_token
+        })
+
+
+# Nicer import names
+checkout = LongClawCheckoutExtension

--- a/longclaw/checkout/jinja2tags.py
+++ b/longclaw/checkout/jinja2tags.py
@@ -4,7 +4,7 @@ from jinja2.ext import Extension
 
 from django.template.loader import get_template
 
-from longclaw.checkout.templatetags.longclawcheckout_tags import gateway_client_js, gateway_token
+from .templatetags.longclawcheckout_tags import gateway_client_js, gateway_token
 
 
 class LongClawCheckoutExtension(Extension):

--- a/longclaw/core/jinja2/core/longclaw_script.html
+++ b/longclaw/core/jinja2/core/longclaw_script.html
@@ -1,0 +1,1 @@
+<script type="text/javascript" src="{{ static(path) }}"></script>

--- a/longclaw/core/jinja2tags.py
+++ b/longclaw/core/jinja2tags.py
@@ -1,0 +1,39 @@
+import jinja2
+import jinja2.nodes
+from jinja2.ext import Extension
+
+from django.template.loader import get_template
+
+# to keep namespaces from colliding
+from longclaw.core.templatetags import longclawcore_tags as lc_tags
+
+
+def longclaw_vendors_bundle():
+    template = get_template('core/longclaw_script.html')
+
+    context = lc_tags.longclaw_vendors_bundle()
+
+    return template.render(context=context)
+
+
+def longclaw_client_bundle():
+    template = get_template('core/longclaw_script.html')
+
+    context = lc_tags.longclaw_client_bundle()
+
+    return template.render(context=context)
+
+
+class LongClawCoreExtension(Extension):
+    def __init__(self, environment):
+        super(LongClawCoreExtension, self).__init__(environment)
+
+        self.environment.globals.update({
+            'longclaw_api_url_prefix': lc_tags.longclaw_api_url_prefix,
+            'longclaw_client_bundle': longclaw_client_bundle,
+            'longclaw_vendors_bundle': longclaw_vendors_bundle,
+        })
+
+
+# Nicer import names
+core = LongClawCoreExtension

--- a/longclaw/core/jinja2tags.py
+++ b/longclaw/core/jinja2tags.py
@@ -5,7 +5,7 @@ from jinja2.ext import Extension
 from django.template.loader import get_template
 
 # to keep namespaces from colliding
-from longclaw.core.templatetags import longclawcore_tags as lc_tags
+from .templatetags import longclawcore_tags as lc_tags
 
 
 def longclaw_vendors_bundle():


### PR DESCRIPTION
# What this does
Addresses: #265 
By adding in some Jinja2 Tag Support! 

I tried to keep this as consistent with how I've seen it done elsewhere, for instance looking at how wagtail handles Jinja2 tag support for their project. 

There is a bit of setup, and I have yet to write tests. 

# Setup
To use these tags instead of the template tags, first you'll need to follow Jinja2 setup guides for Django templating, and [wagtail templating](http://docs.wagtail.io/en/v2.6.2/advanced_topics/jinja2.html). Namely my `settings.py` file looks like this in the end with all the important bits:
```
...
TEMPLATES = [
    {
        'BACKEND': 'django.template.backends.jinja2.Jinja2',
        'APP_DIRS': True,
        'DIRS': [
            os.path.join(DJANGO_ROOT, 'jinja2'),
        ],
        'OPTIONS': {
            'environment': '<YourProjectNameHere>.jinja2.environment',
            'extensions': [
                'wagtail.core.jinja2tags.core',
                'wagtail.admin.jinja2tags.userbar',
                'wagtail.images.jinja2tags.images',
                'longclaw.core.jinja2tags.core',
                'longclaw.basket.jinja2tags.basket',
                'longclaw.checkout.jinja2tags.checkout',
            ]
        },
    },
    # Django Template Settings
    # If you have default template tag support
    ...
]
```

I've got this working on a personal project, but have not run it through the longclaw test suite yet.

# What still needs to be done
- [ ] Tests should probably be written for some of this, even though it extends from the templatetags already written
- [ ] Testing on the longclaw test suite