### PR TITLE
Remove link to ProductSerialiser if needed

### DIFF
--- a/longclaw/products/serializers.py
+++ b/longclaw/products/serializers.py
@@ -10,7 +10,8 @@ class ProductSerializer(serializers.ModelSerializer):
 
 class ProductVariantSerializer(serializers.ModelSerializer):
 
-    product = ProductSerializer()
+    if maybe_get_product_model():
+        product = ProductSerializer()
 
     class Meta:
         model = ProductVariant


### PR DESCRIPTION
Longclaw requires only ProductVariation model, Product model is defined
as foreign key from it. If Product model is undefined that way, related
serializer can't be created and api endpoint shatters.
Not sure how important this link is.
